### PR TITLE
Changed the order of parameters for mysqli_real_escape_string

### DIFF
--- a/inc/database.inc.php
+++ b/inc/database.inc.php
@@ -540,6 +540,6 @@ class SB_DatabaseMySQLPhp43 extends SB_DatabaseMySQL
 
     function escapeString($str)
     {
-        return mysqli_real_escape_string(str_replace('\\0','\\\\0',$str), $this->connection);
+        return mysqli_real_escape_string($this->connection, str_replace('\\0','\\\\0',$str));
     }
 }


### PR DESCRIPTION
The parameters of mysqli_real_escape_string seem to have been switched: The problem caused sitebar to reject any logging for a user stored in mysql.
