### PR TITLE
Cookies: Add SameSite=None for Chrome Addon to function (fixes #30)

### DIFF
--- a/inc/usermanager.inc.php
+++ b/inc/usermanager.inc.php
@@ -257,7 +257,7 @@ class SB_UserManager extends SB_ErrorHandler
         if (version_compare(PHP_VERSION, "5.2.0", ">="))
         {
             // set HttpOnly if PHP supports it
-            setcookie($name, $value, $expires, "/", "", isset($_SERVER["HTTPS"]), $httponly);
+            setcookie($name, $value, $expires, "/; SameSite=None", "", isset($_SERVER["HTTPS"]), $httponly);
         }
         else
         {

--- a/js/sitebar.js
+++ b/js/sitebar.js
@@ -139,13 +139,13 @@ function SB_buttonOut(btn, force)
 function SB_storeSearch()
 {
     var searchText = document.getElementById('fldSearch').value;
-    document.cookie = 'SB3SEARCH='+encodeURIComponent(searchText);
+    document.cookie = 'SB3SEARCH='+encodeURIComponent(searchText)+";SameSite=None;Secure";
 }
 
 function SB_storePosition()
 {
-    document.cookie = 'SB3TOP='+SB_getTop();
-    document.cookie = 'SB3LEFT='+SB_getLeft();
+    document.cookie = 'SB3TOP='+SB_getTop()+";SameSite=None;Secure";
+    document.cookie = 'SB3LEFT='+SB_getLeft()+";SameSite=None;Secure";
 }
 
 function SB_hasClass(obj, className)
@@ -732,7 +732,7 @@ function SB_WFI(imgObj)
 
 function SB_initCommander()
 {
-    document.cookie = 'SB3COOKIE=1';
+    document.cookie = 'SB3COOKIE=1'+";SameSite=None;Secure";
 
     if (document.getElementById('focused'))
     {
@@ -880,7 +880,7 @@ function SB_saveState(id, state)
 function SB_saveCookie(value)
 {
     var expires = new Date(new Date().getTime()+1000*60*60*24*7).toGMTString();
-    document.cookie = 'SB3NODES='+value+'; expires=' + expires;
+    document.cookie = 'SB3NODES='+value+'; expires=' + expires+";SameSite=None;Secure";
 }
 
 /**
@@ -1224,7 +1224,7 @@ function SB_menuOn(event, obj)
 
     if (menuDIV=='node')
     {
-        document.cookie = 'SB3CTXROOT='+obj.id.substr(1);
+        document.cookie = 'SB3CTXROOT='+obj.id.substr(1)+";SameSite=None;Secure";
     }
 
     // Mark folder as opened


### PR DESCRIPTION
This is a fix for the [Sitebar Chrome Addon](https://chrome.google.com/webstore/detail/sitebar-addon/mjcijcecjeigmnpemkbgjlhfeolncbon?hl=en&gl=EN) complaining that Cookies could not set. It boiled down to the `SameSite` setting being defaulted to `Lax`. Therefore the Cookies could not be set.

This PR adds
1. `;SameSame=None` to the PHP setCookie() function
2. `;SameSite=None;Secure` to all Cookies set via JavaScript

This resolved the issue for me. Please have a thorough look at it. E.g., are there any security implications to consider?