### PR TITLE
fix PHP8 compatibility

### DIFF
--- a/inc/page.inc.php
+++ b/inc/page.inc.php
@@ -36,7 +36,7 @@ if (!function_exists('version_compare') || version_compare(phpversion(), MIN_VER
 
 /******************************************************************************/
 
-if (get_magic_quotes_gpc()) // We need this until PHP 6.0?
+if (function_exists("get_magic_quotes_gpc") && get_magic_quotes_gpc()) // We need this until PHP 6.0?
 {
    function stripslashes_deep($value)
    {
@@ -325,7 +325,7 @@ class SB_Page extends SB_ErrorHandler
             $url = 'http' . ($https?'s':'') . '://' . $basedir;
         }
 
-        if ($url{strlen($url)-1} != '/')
+        if ($url[strlen($url)-1] != '/')
         {
             $url .= '/';
         }
@@ -370,7 +370,7 @@ class SB_Page extends SB_ErrorHandler
             $url = '';
         }
 
-        if (strlen($url)>0 && $url{strlen($url)-1} != '/')
+        if (strlen($url)>0 && $url[strlen($url)-1] != '/')
         {
             $url .= '/';
         }
@@ -554,7 +554,7 @@ SB_gSkinDir = '<?php echo SB_Skin::webPath()?>/';
 <?php
     }
 
-    function foot()
+    public static function foot()
     {
 ?>
 </body>

--- a/inc/pageparser.inc.php
+++ b/inc/pageparser.inc.php
@@ -848,7 +848,7 @@ class SB_PageParser extends SB_ErrorHandler
 
         if (isset($base['path']))
         {
-            if ($base['path']{strlen($base['path'])-1} == '/')
+            if ($base['path'][strlen($base['path'])-1] == '/')
             {
                 $oldpath = $base['path'];
             }

--- a/inc/token.inc.php
+++ b/inc/token.inc.php
@@ -102,7 +102,7 @@ class SB_Token extends SB_ErrorHandler
         $tkcharslen = strlen($tkchars)-1;
         for ($i=0 ; $i<$size ; $i++ )
         {
-            $token .= $tkchars{rand(0,$tkcharslen)};
+            $token .= $tkchars[rand(0,$tkcharslen)];
         }
         return $token;
     }

--- a/inc/writers/sitebar_ajax.inc.php
+++ b/inc/writers/sitebar_ajax.inc.php
@@ -43,8 +43,10 @@ class SB_Writer_sitebar_ajax extends SB_Writer_sitebar
         {
             array_push($this->treearr, $this->iempty);
         }
-
-        $node->root->isRoot = false;
+	if(!is_null($node->root))
+	{
+            $node->root->isRoot = false;
+	}
     }
 
 /* Opera 8.5 does not support responseXML


### PR DESCRIPTION
I tried sitebar on PHP 8.0 and found a few fatal errors and tried to fix them.

this is mostly "Array and string offset access syntax with curly braces is no longer supported" (see  [deprecate_curly_braces_array_access](https://wiki.php.net/rfc/deprecate_curly_braces_array_access) )
one instance of deprecated and remove function get-magic-quotes-gpc.php (see [function.get-magic-quotes-gpc](https://www.php.net/manual/de/function.get-magic-quotes-gpc.php) )
and SB_Page::foot is called statically in inc/writers/sitebar.inc.php:1088