### PR TITLE
Some php8 fixes

### DIFF
--- a/.htaccess
+++ b/.htaccess
@@ -11,3 +11,8 @@
 	RewriteRule ^news/(\w+)             news.php?root=$1 [L,QSA]
 	RewriteRule ^root/(\w+)             index.php?root=$1 [L,QSA]
 </ifmodule>
+
+#Turns off the expires headers for Apache
+<IfModule mod_expires.c>
+  ExpiresActive Off
+</IfModule>

--- a/command.php
+++ b/command.php
@@ -829,11 +829,11 @@ class SB_CommandWindow extends SB_ErrorHandler
             // No translation here
             if ($ret)
             {
-                $this->warn('%s', sprintf($okStr, $user['completenamehtml']));
+                $this->warn('%s', array(sprintf($okStr, $user['completenamehtml'])));
             }
             else
             {
-                $this->error('%s', sprintf($errorStr, $user['completenamehtml']));
+                $this->error('%s', array(sprintf($errorStr, $user['completenamehtml'])));
             }
         }
 
@@ -854,7 +854,7 @@ class SB_CommandWindow extends SB_ErrorHandler
     {
         if (!strstr($email,'@'))
         {
-            $this->error('The e-mail %s does not look correctly!', $email);
+            $this->error('The e-mail %s does not look correctly!', array($email));
             return false;
         }
         return true;
@@ -2424,7 +2424,7 @@ class SB_CommandWindow extends SB_ErrorHandler
 
         if ($counter>1)
         {
-            $this->warn('Sent to %s recipients.', $counter);
+            $this->warn('Sent to %s recipients.', array($counter));
         }
     }
 
@@ -3542,11 +3542,11 @@ class SB_CommandWindow extends SB_ErrorHandler
                 {
                     if ($item=='username')
                     {
-                        $this->error('User with username "%s" does not exist!', $value);
+                        $this->error('User with username "%s" does not exist!', array($value));
                     }
                     else
                     {
-                        $this->error('User with email "%s" does not exist!', $value);
+                        $this->error('User with email "%s" does not exist!', array($value));
                     }
                     $this->goBack();
                     return;
@@ -3790,7 +3790,7 @@ class SB_CommandWindow extends SB_ErrorHandler
 
             if ($user==null)
             {
-                $this->warn('User with username "%s" has already been rejected!', $username);
+                $this->warn('User with username "%s" has already been rejected!', array($username));
                 return;
             }
 
@@ -3815,7 +3815,7 @@ class SB_CommandWindow extends SB_ErrorHandler
 
             if ($user==null)
             {
-                $this->warn('User with uid %d has already been rejected!', $uid);
+                $this->warn('User with uid %d has already been rejected!', array($uid));
                 continue;
             }
 
@@ -4393,7 +4393,7 @@ class SB_CommandWindow extends SB_ErrorHandler
 
         if ($this->um->uid == SB_reqVal('uid',true))
         {
-            $this->error('Use "%s" command to delete own account!', SB_T('Delete Account'));
+            $this->error('Use "%s" command to delete own account!', array(SB_T('Delete Account')));
             return null;
         }
 
@@ -5154,7 +5154,7 @@ class SB_CommandWindow extends SB_ErrorHandler
 
         if (preg_match('/[<>"]/',SB_reqVal('name')))
         {
-            $this->error('Group name must not contain following characters [%s]!', '&lt;&gt;&quot;');
+            $this->error('Group name must not contain following characters [%s]!', array('&lt;&gt;&quot;'));
             return;
         }
 

--- a/inc/errorhandler.inc.php
+++ b/inc/errorhandler.inc.php
@@ -217,6 +217,7 @@ class SB_ErrorHandler
         }
         else
         {
+            // TODO-php8 Many usages of warn() and error() unaudited $arr must be array()
             $txt = SB_T($msg,$arr);
         }
 

--- a/inc/faviconcache.inc.php
+++ b/inc/faviconcache.inc.php
@@ -316,10 +316,16 @@ class SB_FaviconCache extends SB_ErrorHandler
     // For backward compatibility PHP < 4.3.0
     function file_get_contents($filename)
     {
-       $fd = fopen($filename, "rb");
-       $content = fread($fd, filesize($filename));
-       fclose($fd);
-       return $content;
+        $fd = fopen($filename, "rb");
+        $fsize = filesize($filename);
+        if($fsize > 0) {
+            $content = fread($fd, filesize($filename));
+        } else {
+            // TODO: Is this a good fix for empty file?
+            $content = "";
+        }
+        fclose($fd);
+        return $content;
     }
 
     // If lid is not specified, the cache wont be updated

--- a/inc/pageparser.inc.php
+++ b/inc/pageparser.inc.php
@@ -155,7 +155,11 @@ class SB_HTTPStream extends SB_ErrorHandler
 
     function read($size=4096)
     {
-        $data = fread($this->connection, $size);
+        if($this->connection) {
+            $data = fread($this->connection, $size);
+        } else {
+            $data = "";
+        }
         if (SB_LOG_HTTP) $this->log('< ', $data);
         return $data;
     }

--- a/inc/writers/sitebar.inc.php
+++ b/inc/writers/sitebar.inc.php
@@ -710,7 +710,7 @@ _DOC;
 
         if ($this->switches['user'] && strlen($this->switches['user']))
         {
-            $message = SB_T("Hide bookmarks from %s!", $this->switches['user']);
+            $message = SB_T("Hide bookmarks from %s!", array($this->switches['user']));
             echo '
 <div id="info"><a href="'.SB_Page::absBaseUrl().'?user=">'.$message.'</a></div>
 ';

--- a/integrator.php
+++ b/integrator.php
@@ -217,7 +217,7 @@ $extra = array
     (
         'label' => 'Sidebar',
         'url' => null,
-        'desc' => SB_P('integrator::hint_sidebar_konqueror', SB_Page::absBaseUrl()),
+        'desc' => SB_P('integrator::hint_sidebar_konqueror', array(SB_Page::absBaseUrl())),
     ),
 
     'hotlist' => array
@@ -281,7 +281,7 @@ $extra = array
     (
         'label' => 'PHP Layers Menu',
         'url' => 'http://phplayersmenu.sourceforge.net/',
-        'desc' => SB_P('integrator::hint_phplm', sprintf('%sindex.php?w=phplm', SB_Page::absBaseUrl())),
+        'desc' => SB_P('integrator::hint_phplm', array(sprintf('%sindex.php?w=phplm', SB_Page::absBaseUrl()))),
     ),
 
 );


### PR DESCRIPTION
This fixes a number of fatal errors in PHP8 due to vsprintf requiring the second argument to be an array
A couple of examples are loading integrator.php and performing a forgot password where the email is not found